### PR TITLE
Bugfix not finding ap tools

### DIFF
--- a/Shells/Controller VM/src/driver.py
+++ b/Shells/Controller VM/src/driver.py
@@ -88,16 +88,13 @@ class ControllerVmDriver (ResourceDriverInterface):
                     s = paramiko.SSHClient()
                     s.set_missing_host_key_policy(paramiko.AutoAddPolicy())
                     s.connect(hostname=context.resource.address, username=username, password=api_session.DecryptPassword(password).Value)
-                    command = 'cd /tmp && git clone https://github.com/Telecominfraproject/wlan-testing.git; cd wlan-testing/tools && chmod +x ap_tools.py'
+                    command = 'cd /tmp && git clone https://github.com/Telecominfraproject/wlan-testing.git; cd wlan-testing && git checkout master && cd tools && chmod +x ap_tools.py'
 
-                    command2 = 'python3 ap_tools.py --host {} --jumphost {} --tty {} --port {} --username {} --password {} --cmd "jffs2reset -y -r"'.format(
+                    command2 = 'cd /tmp/wlan-testing/tools && python3 ap_tools.py --host {} --jumphost {} --tty {} --port {} --username {} --password {} --cmd "jffs2reset -y -r"'.format(
                               ap_ip, ap_jumphost, ap_tty, ap_port, ap_user, api_session.DecryptPassword(ap_password).Value)
-
-                    command3 = "cd /tmp && rm -f -r wlan-testing"
 
                     (stdin, stdout, stderr) = s.exec_command(command)
                     (stdin2, stdout2, stderr2) = s.exec_command(command2)
-                    (stdin3, stdout3, stderr3) = s.exec_command(command3)
 
                     output = ''
                     errors = ''
@@ -105,7 +102,7 @@ class ControllerVmDriver (ResourceDriverInterface):
                         errors += line
                     if stdout2.channel.recv_exit_status() != 0:
                         api_session.WriteMessageToReservationOutput(context.reservation.reservation_id,
-                                                                    'AP Factory Reset failed: ' + errors)
+                                                                    'AP Factory Reset failed on {}: '.format(context.resource.address) + errors)
                         raise Exception('Error executing Script: ' + errors)
                     else:
                         api_session.WriteMessageToReservationOutput(context.reservation.reservation_id,

--- a/Shells/Controller VM/src/driver.py
+++ b/Shells/Controller VM/src/driver.py
@@ -98,6 +98,8 @@ class ControllerVmDriver (ResourceDriverInterface):
 
                     output = ''
                     errors = ''
+                    for line in stdout2.readlines():
+                        output += line
                     for line in stderr2.readlines():
                         errors += line
                     if stdout2.channel.recv_exit_status() != 0:
@@ -108,6 +110,8 @@ class ControllerVmDriver (ResourceDriverInterface):
                         api_session.WriteMessageToReservationOutput(context.reservation.reservation_id,
                                                                     'AP Factory Reset Complete.')
                     s.close()
+
+                    return output
 
         except Exception as e:
             logger.info("Error executing Script: {}".format(e.message))

--- a/Shells/ap-v2/src/driver.py
+++ b/Shells/ap-v2/src/driver.py
@@ -191,6 +191,7 @@ class ApV2Driver (ResourceDriverInterface):
                         raise Exception(repr(errors))
                 else:
                     api_session.WriteMessageToReservationOutput(context.reservation.reservation_id, "Digicert AP Redirect Successful.")
+                    return output
 
     def powerOtherAPs(self, context, cmd='on'):
         res_id = context.reservation.reservation_id

--- a/Shells/ap-v2/src/driver.py
+++ b/Shells/ap-v2/src/driver.py
@@ -224,10 +224,10 @@ class ApV2Driver (ResourceDriverInterface):
                         s.set_missing_host_key_policy(paramiko.AutoAddPolicy())
                         s.connect(hostname=terminal_ip, username=terminal_user,
                                   password=terminal_pass)
-                        command = "cd /tmp && git clone https://github.com/Telecominfraproject/wlan-testing.git; cd wlan-testing/tools && python3 {} --host {} --user {} --password {} --action {} --port {}".format(
-                            PDU_SCRIPT_NAME, hostname, username, password, cmd, port)
+                        command = "cd /tmp && git clone https://github.com/Telecominfraproject/wlan-testing.git; cd wlan-testing && git checkout master"
 
-                        command2 = "cd /tmp && rm -f -r wlan-testing"
+                        command2 = "cd /tmp/wlan-testing/tools && python3 {} --host {} --user {} --password {} --action {} --port {}".format(
+                            PDU_SCRIPT_NAME, hostname, username, password, cmd, port)
 
                         (stdin, stdout, stderr) = s.exec_command(command)
                         (stdin2, stdout2, stderr2) = s.exec_command(command2)
@@ -238,7 +238,7 @@ class ApV2Driver (ResourceDriverInterface):
                             output += line
                         for line in stderr.readlines():
                             errors += line
-                        if stdout.channel.recv_exit_status() != 0:
+                        if stdout2.channel.recv_exit_status() != 0:
                             api_session.WriteMessageToReservationOutput(context.reservation.reservation_id,'PDU Power command failed: ' + errors)
                             raise Exception(errors)
                         else:


### PR DESCRIPTION
No longer removes the wlan-testing repo. Just attempts to clone repo (which fails but is ignored if already exists). Then makes sure is up to date on master. Also apredirect and factory reset commands now return output, which will print to activity feed, and maybe output. Can maybe remove from output window if flag is set in setup script.